### PR TITLE
Create growth stage

### DIFF
--- a/src/api/controllers/growth-stage-controller.js
+++ b/src/api/controllers/growth-stage-controller.js
@@ -1,0 +1,62 @@
+// src/api/controllers/growth-stage-controller.js
+
+/**
+ * @module growth-stage-controller
+ * Ecospace GrowthStage Controller
+ * 
+ * @description This module defines the controller for handling growth stage related requests in the Ecospace backend.
+ * It includes functions for creating growth stage, fetching all growth stages, fetching a growth stage by its ID,
+ * updating growth stage details, and deleting a growth stage.
+ * This controller is used to process requests related to growth stage management and interact with the growth stage service.
+ * It handles the business logic for growth stage-related operations and returns appropriate responses to the client.
+ * 
+ * @requires ../../utils/common
+ * @requires ../services/growth-stage-service
+ * @exports { createGrowthStage }
+ */
+
+// Custom module imports
+const { toSnakeCaseKeys } = require("../../utils/common");
+const { saveGrowthStage } = require("../services/growth-stage-service");
+
+/**
+ * @function createGrowthStage
+ * @post /growth-stages
+ *
+ * @description Handles the creation of a new growth stage entry.
+ * This function processes the request body to extract growth stage details,
+ * validates the required fields, and calls the growth stage service to save the growth stage details to the database
+ * and returns the saved growth stage object in the response.
+ *
+ * @param {Object} req - The request object containing the growth stage details in the body.
+ * @param {Object} res - The response object used to send the response back to the client.
+ * @returns {Object} - Returns a JSON response with the saved growth stage object and a success message.
+ * @throws {Error} - Throws an error if the save operation fails, returning a 500 status code with an error message.
+ */
+const createGrowthStage = async (req, res) => {
+    let growthStageDetails = {};
+    // Get body of the request
+    if (!req.body) return res.status(400).json({ message: "Required body" });
+    console.log(req.body);
+    // Destructure the growth stage details from the request body
+    const { description, max_days: maxDays, min_days: minDays,
+        name, order } = req.body;
+
+    // Add mandatory values to growth stage details
+    growthStageDetails = { description, name, order };
+    // Add optional values
+    if (![ undefined, null ].includes(maxDays)) growthStageDetails.maxDays = maxDays;
+    if (![ undefined, null ].includes(minDays)) growthStageDetails.minDays = minDays;
+
+    // Try to save the growth stage details
+    try {
+        const growthStage = await saveGrowthStage(growthStageDetails);
+        return res.status(201).json({ data: toSnakeCaseKeys(growthStage), message: 'GrowthStage created successfully' })
+    } catch (error) {
+        console.error("Error creating soil:", error);
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// Export the controller handler functions to use in the routes
+module.exports = { createGrowthStage };

--- a/src/api/controllers/plant-controller.js
+++ b/src/api/controllers/plant-controller.js
@@ -121,7 +121,7 @@ const fetchAllPlants = async (req, res) => {
         let { category, growth_cycle: growthCycle, growth_habit: growthHabit,
             ideal_season: idealSeason, purpose, limit, page, sort_by: sortBy, sort_order: sortOrder } = req.sanitizedQuery;
         const DEFAULT_LIMIT = 10, MAX_LIMIT = 100, DEFAULT_PAGE = 1 ; // Default pagination values
-        const SORT_PARAMS = ["name", "createdAt"], DEFAULT_SORT_BY = "createdAt", DEFAULT_SORT_ORDER = "asc"; // Default sorting values 
+        const SORT_PARAMS = ["name", "created_at"], DEFAULT_SORT_BY = "created_at", DEFAULT_SORT_ORDER = "asc"; // Default sorting values 
         /** 
          * Validations: Pagination
          *
@@ -146,7 +146,7 @@ const fetchAllPlants = async (req, res) => {
          * Validations: Sorting
          *
          * If sortBy and sortOrder are provided, use them to sort results else use default values
-         * sortBy: Field to sort by (default is createdAt)
+         * sortBy: Field to sort by (default is created_at)
          * sortOrder: Order to sort by (default is asc)
          * Ensure sortBy is one of the allowed fields and sortOrder is either asc or desc
          *

--- a/src/api/routes/growth-stage-route.js
+++ b/src/api/routes/growth-stage-route.js
@@ -1,0 +1,28 @@
+// src/api/routes/growth-stage-route.js
+
+/**
+ * @module growth-stage-route
+ * Ecospace GrowthStage Routes
+ * 
+ * @description This module defines the routes for growth stage-related endpoints in the Ecospace backend.
+ * It includes routes for creating growth stage, fetching all growth stages, and fetching a growth stage by its ID.
+ * It uses the Express Router and applies validation middleware to ensure that the requests are properly formatted.
+ * 
+ * @requires express
+ * @exports routes
+ */
+
+// Core module imports
+const { Router } = require("express");
+// const { growthStageValidator } = require("../middlewares/growth-stage-middleware");
+// const { validationErrorHandler } = require("../middlewares/error-middleware");
+const { createGrowthStage } = require("../controllers/growth-stage-controller");
+
+// Initialize the router
+const routes = Router();
+
+// Define the growth stage routes
+routes.post("/", createGrowthStage);
+
+// Export the routes for use in the main application
+module.exports = routes;

--- a/src/api/services/growth-stage-service.js
+++ b/src/api/services/growth-stage-service.js
@@ -1,0 +1,43 @@
+// src/api/services/growth-stage-service.js
+
+/**
+ * @module growth-stage-service
+ * Ecospace Growth Stage Service
+ * 
+ * @description This module provides services related to growth stage management in the Ecospace backend.
+ * It includes functions for saving growth stage details, fetching all growth stages, fetching a growth stage by its ID,
+ * updating growth stage details, and deleting a growth stage.
+ * This service is used to interact with the growth stage data in the database and perform operations related to growth stage management.
+ *
+ * @requires ../../db/models/GrowthStage
+ * @exports { saveGrowthStage }
+ */
+
+// Custom module imports
+const { PLANT_GROWTH_STAGE } = require("../../constants/plant-constant");
+const GrowthStage = require("../../db/models/GrowthStage");
+
+/**
+ * @function saveGrowthStage
+ * 
+ * @description Saves a growth stage to the PostgreSQL database using Sequelize.
+ * This function takes growth stage details as input and creates a new growth stage entry in the database.
+ * It returns the saved growth stage object or throws an error if the save operation fails.
+ * 
+ * @param {Object} growthStageDetails - The details of the growth stage to be saved.
+ * @returns {Promise<Object>} - The saved growth stage object.
+ * @throws {Error} - Throws an error if the save operation fails.
+ */
+const saveGrowthStage = async (growthStageDetails) => {
+    try {
+        // Save the details for the growth stage
+        const growthStage = await GrowthStage.create(growthStageDetails);
+        return growthStage.toJSON(); // Convert the Sequelize instance to a plain object
+    } catch (error) {
+        console.error("Error saving growth stage: ", error?.message || error);
+        throw new Error("Failed to save growth stage");
+    }
+};
+
+// Export the service functions to use in the controllers
+module.exports = { saveGrowthStage };

--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,7 @@ const express = require("express");
 // Custom module imports
 const plantRoutes = require("./api/routes/plant-route");
 const soilRoutes = require("./api/routes/soil-route");
+const growthStageRoutes = require("./api/routes/growth-stage-route");
 
 // Initialize the Express application
 const app = express();
@@ -29,6 +30,7 @@ app.use(express.json());
 // Middleware to parse various ecospace service routes
 app.use("/plants", plantRoutes); // Plant-related routes
 app.use("/soils", soilRoutes); // Soil-related routes
+app.use("/growth-stages", growthStageRoutes); // GrowthStage-related routes
 app.get("/", (_req, res) => res.status(200).send("Welcome to Ecospace backend"));
 
 // Export the app for use in other modules

--- a/src/db/models/GrowthStage.js
+++ b/src/db/models/GrowthStage.js
@@ -1,0 +1,111 @@
+// src/db/models/GrowthStage.js
+
+/**
+ * @module GrowthStage
+ * Ecospace GrowthStage Model
+ * 
+ * @description This module defines the GrowthStage model for the Ecospace backend.
+ * It includes the schema for soil properties such as name, description, order, image_url, 
+ * min_days, max_days, notes.
+ * The model is used to interact with the database for growth stage related operations.
+ *
+ * @requires sequelize
+ * @requires ../../constants/plant-constant
+ * @exports GrowthStage
+ */
+
+// Core module imports
+const { DataTypes } = require("sequelize");
+
+// Custom module imports
+const sequelize = require("../index");
+const { PLANT_GROWTH_STAGE } = require("../../constants/plant-constant");
+
+/**
+ * @constant GrowthStage
+ *
+ * @description
+ *
+ * @type {Model}
+ * @property {UUID} id - Unique identifier for the growth stage (UUID).
+ * @property {string} description - The description for the growth stage.
+ * @property {string} imageUrl - The single image url to show the growth stage
+ * @property {number} maxDays - The maximum number of days for the growth stage to complete.
+ * @property {number} minDays - The minimum number of days for the growth stage to complete.
+ * @property {string} name - The unique name of the growth stage
+ * @property {number} order - The unique number to mark the rank of the growth stage
+ * @returns {Model} - Returns the GrowthStage model instance.
+ * 
+ * @example
+ * // Example usage:
+ * const GrowthStage = require('./models/GrowthStage');
+ * const newGrowthStage = await GrowthStage.create({
+ *  name: 'germination',
+ *  description: 'Germination is the first stage of a plant’s life cycle.',
+ *  order: 1,
+ *  imageUrl: 'https://image-link-germination.jpg',
+ *  minDays: 0,
+ *  maxDays: 5,
+ * });
+ */
+const GrowthStage = sequelize.define('GrowthStage', {
+    id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+    },
+    description: {
+        type: DataTypes.TEXT, // No limit to characters
+        allowNull: true,
+    },
+    imageUrl: {
+        type: DataTypes.STRING,
+        allowNull: true,
+    },
+    maxDays: {
+        type:  DataTypes.INTEGER,
+        allowNull: true,
+        validate: {
+            min: 1 // Max duration days should be min of 1 day
+        },
+    },
+    minDays: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        validate: {
+            min: 0 // Min duration days can be 0 as well (ex: germination)
+        },
+    },
+    name: {
+        type: DataTypes.ENUM(Object.values(PLANT_GROWTH_STAGE)),
+        allowNull: false,
+        // unique: true,
+    },
+    order: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        unique: true,
+        validate: {
+            min: 1 // Order always starts from 1
+        },
+    },
+}, {
+    validate: {
+        minLessThanMax() {
+            if (this.minDays != null && this.maxDays != null && this.minDays >= this.maxDays) {
+                throw new Error('minDays must be less than maxDays');
+            }
+        }
+    },
+    tableName: 'growth_stages', // Use a custom table name
+    timestamps: true, // Enable createdAt and updatedAt fields
+    underscored: true, // Use snake_case for database fields
+});
+
+// Synchronize the model with the database
+sequelize.sync()
+    .then(() => console.log("GrowthStage model synchronized with the database"))
+    .catch(error => console.error("Error synchronizing GrowthStage model:", error?.message || error));
+
+// Export the GrowthStage model
+module.exports = GrowthStage;

--- a/src/db/models/Plant.js
+++ b/src/db/models/Plant.js
@@ -89,17 +89,14 @@ const Plant = sequelize.define('Plant', {
     },
     growthCycle: {
         type: DataTypes.ENUM(Object.values(PLANT_GROWTH_CYCLE)), // Use constants
-        field: 'growth_cycle', // Use snake_case for database field
         allowNull: false, // Required field
     },
     growthHabit: {
         type: DataTypes.ENUM(Object.values(PLANT_GROWTH_HABIT)), // Use constants
-        field: 'growth_habit', // Use snake_case for database field
         allowNull: false, // Required field
     },
     idealSeason: {
         type: DataTypes.ENUM(Object.values(SEASON)), // Use constants
-        field: 'ideal_season', // Use snake_case for database field
         allowNull: false, // Required field
     },
     purpose: {
@@ -108,24 +105,20 @@ const Plant = sequelize.define('Plant', {
     },
     commonNames: {
         type: DataTypes.ARRAY(DataTypes.STRING),
-        field: 'common_names', // Use snake_case for database field
         defaultValue: [], // Default to an empty array if no value is provided
     },
     commonPests: {
         type: DataTypes.ARRAY(DataTypes.STRING),
-        field: 'common_pests', // Use snake_case for database field
         allowNull: true, // Optional field
         defaultValue: [], // Default to an empty array if no value is provided
     },
     compatiblePlants: {
         type: DataTypes.ARRAY(DataTypes.STRING),
-        field: 'compatible_plants', // Use snake_case for database field
         allowNull: true, // Optional field
         defaultValue: [], // Default to an empty array if no value is provided
     },
     growthStages: {
         type: DataTypes.ARRAY(DataTypes.STRING),
-        field: 'growth_stages', // Use snake_case for database field
         // Custom validation to ensure growth_stages is an array of allowed growth stages
         validate: {
             isValidGrowthStages(value) {
@@ -145,17 +138,14 @@ const Plant = sequelize.define('Plant', {
     },
     recommendedFertilizers: {
         type: DataTypes.ARRAY(DataTypes.STRING),
-        field: 'recommended_fertilizers', // Use snake_case for database field
         defaultValue: [], // Default to an empty array if no value is provided
     },
     regionCompatibility: {
         type: DataTypes.ARRAY(DataTypes.STRING),
-        field: 'region_compatibility', // Use snake_case for database field
         defaultValue: [], // Default to an empty array if no value is provided
     },
     scientificName: {
         type: DataTypes.STRING(50), // Limit to 50 characters
-        field: 'scientific_name', // Use snake_case for database field
         unique: true, // Ensure scientific names are unique
         allowNull: true, // Optional field
     },
@@ -163,13 +153,14 @@ const Plant = sequelize.define('Plant', {
         type: DataTypes.ARRAY(DataTypes.STRING),
         defaultValue: [], // Default to an empty array if no value is provided
     },
-}, {
+}, {    
     timestamps: true,
     tableName: 'plants', // Set table name
+    underscored: true, // // Use snake_case for database fields
 });
 
 // Synchronize the model with the database
-Plant.sync({ alter: true })
+Plant.sync()
     .then(() => console.log('Plant model synchronized with the database'))
     .catch(error => console.error('Error synchronizing Plant model:', error));
     

--- a/src/db/models/Soil.js
+++ b/src/db/models/Soil.js
@@ -128,7 +128,7 @@ const Soil = sequelize.define("Soil", {
 });
 
 // Synchronize the model with the database
-Soil.sync({ alter: true })
+Soil.sync()
     .then(() => console.log("Soil model synchronized with the database"))
     .catch(error => console.error("Error synchronizing Soil model:", error?.message || error));
 


### PR DESCRIPTION
1. Added endpoint to handle growth stage creation with respective controller and service functions and a sequelize schema for growth stage with bare minimum validations.
2. Also removed alter: true while model sync - which is not required in production codes.
Note: Because it will cause issues giving duplicate errors on indexes, might eventually need to drop entire tables, database as well.